### PR TITLE
Additional instrumentation

### DIFF
--- a/src/main/java/com/github/arteam/dropwizard/http2/client/Http2ClientBuilder.java
+++ b/src/main/java/com/github/arteam/dropwizard/http2/client/Http2ClientBuilder.java
@@ -1,11 +1,14 @@
 package com.github.arteam.dropwizard.http2.client;
 
+import com.github.arteam.dropwizard.http2.client.names.NameStrategies;
+import com.github.arteam.dropwizard.http2.client.names.NameStrategy;
 import com.github.arteam.dropwizard.http2.client.transport.ClientTransportFactory;
 import com.google.common.base.Strings;
 import io.dropwizard.setup.Environment;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http2.client.HTTP2Client;
 import org.eclipse.jetty.util.HttpCookieStore;
 
 import javax.annotation.Nullable;
@@ -35,8 +38,10 @@ public class Http2ClientBuilder {
 
     public HttpClient build(@Nullable String name) {
         ClientTransportFactory connectionFactoryBuilder = configuration.getConnectionFactoryBuilder();
+
+        final NameStrategy naming = NameStrategies.prefixedStrategy(HTTP2Client.class, name, NameStrategies.HOST);
         HttpClient httpClient = new InstrumentedHttpClient(connectionFactoryBuilder.httpClientTransport(),
-                connectionFactoryBuilder.sslContextFactory(), environment.metrics(), name);
+                connectionFactoryBuilder.sslContextFactory(), environment.metrics(), naming);
         httpClient.setConnectTimeout(configuration.getConnectionTimeout().toMilliseconds());
         httpClient.setIdleTimeout(configuration.getIdleTimeout().toMilliseconds());
         httpClient.setFollowRedirects(configuration.isFollowRedirects());

--- a/src/main/java/com/github/arteam/dropwizard/http2/client/InstrumentedListener.java
+++ b/src/main/java/com/github/arteam/dropwizard/http2/client/InstrumentedListener.java
@@ -1,0 +1,129 @@
+package com.github.arteam.dropwizard.http2.client;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.github.arteam.dropwizard.http2.client.names.NameStrategy;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.api.Response;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+public class InstrumentedListener extends Request.Listener.Adapter {
+
+    private final MetricRegistry metricRegistry;
+    private final NameStrategy name;
+
+    /**
+     * The time taken between when request data starts being sent and response
+     * data is first received
+     */
+    private Timer timeToFirstByte;
+
+    /**
+     * Time taken to send all request data and receive all response data
+     */
+    private Timer total;
+
+    private Timer.Context totalContext;
+    private Timer.Context ttfbContext;
+    private Timer.Context queueContext;
+
+    /**
+     * Number of requests that result in a successful status code
+     */
+    private Meter request2xx;
+
+    /**
+     * Number of requests that result in a client error status code
+     */
+    private Meter request4xx;
+
+    /**
+     * Number of requests that result in a server error status code
+     */
+    private Meter request5xx;
+
+    /**
+     * Number of requests that result in a non 2xx, 4xx, or 5xx status code
+     */
+    private Meter requestOtherStatus;
+
+    /**
+     * Number of requests that failed and did not receive a status code
+     */
+    private Meter requestException;
+
+    /**
+     * The number of requests in transit to the server
+     */
+    private Counter inflight;
+
+    /**
+     * The number of requests currently queued and ready to be sent
+     */
+    private Counter onQueue;
+
+    public InstrumentedListener(MetricRegistry metricRegistry, NameStrategy name) {
+        this.metricRegistry = metricRegistry;
+        this.name = name;
+    }
+
+    @Override
+    public void onQueued(Request request) {
+        final String metricName = name.nameFor(request);
+        final Timer queue = metricRegistry.timer(name(metricName, "queue-wait"));
+        total = metricRegistry.timer(name(metricName, "total"));
+        timeToFirstByte = metricRegistry.timer(name(metricName, "time-to-first-byte"));
+        request2xx = metricRegistry.meter(name(metricName, "2xx"));
+        request4xx = metricRegistry.meter(name(metricName, "4xx"));
+        request5xx = metricRegistry.meter(name(metricName, "5xx"));
+        requestOtherStatus = metricRegistry.meter(name(metricName, "other-status"));
+        requestException = metricRegistry.meter(name(metricName, "exception"));
+        inflight = metricRegistry.counter(name(metricName, "inflight"));
+        onQueue = metricRegistry.counter(name(metricName, "on-queue"));
+        onQueue.inc();
+        queueContext = queue.time();
+    }
+
+    @Override
+    public void onBegin(Request request) {
+        onQueue.dec();
+        queueContext.stop();
+        totalContext = total.time();
+    }
+
+    @Override
+    public void onCommit(Request request) {
+        ttfbContext = timeToFirstByte.time();
+        inflight.inc();
+    }
+
+    public void onResponseBegin() {
+        ttfbContext.stop();
+    }
+
+    public void onResponseComplete(Throwable exn, Response response) {
+        totalContext.stop();
+        inflight.dec();
+
+        if (exn != null) {
+            requestException.mark();
+        } else {
+            switch (javax.ws.rs.core.Response.Status.Family.familyOf(response.getStatus())) {
+                case SUCCESSFUL:
+                    request2xx.mark();
+                    break;
+                case SERVER_ERROR:
+                    request5xx.mark();
+                    break;
+                case CLIENT_ERROR:
+                    request4xx.mark();
+                    break;
+                default:
+                    requestOtherStatus.mark();
+            }
+        }
+    }
+}

--- a/src/main/java/com/github/arteam/dropwizard/http2/client/names/NameStrategies.java
+++ b/src/main/java/com/github/arteam/dropwizard/http2/client/names/NameStrategies.java
@@ -1,0 +1,21 @@
+package com.github.arteam.dropwizard.http2.client.names;
+
+import org.eclipse.jetty.client.api.Request;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+public class NameStrategies {
+    public static NameStrategy HOST = Request::getHost;
+
+    public static NameStrategy METHOD = Request::getMethod;
+
+    public static NameStrategy FULL = request -> name(request.getHost(), request.getMethod(), request.getPath());
+
+    public static NameStrategy prefixedStrategy(String prefix, NameStrategy strategy) {
+        return request -> name(prefix, strategy.nameFor(request));
+    }
+
+    public static NameStrategy prefixedStrategy(Class<?> clazz, String prefix, NameStrategy strategy) {
+        return request -> name(clazz, prefix, strategy.nameFor(request));
+    }
+}

--- a/src/main/java/com/github/arteam/dropwizard/http2/client/names/NameStrategy.java
+++ b/src/main/java/com/github/arteam/dropwizard/http2/client/names/NameStrategy.java
@@ -1,0 +1,15 @@
+package com.github.arteam.dropwizard.http2.client.names;
+
+import org.eclipse.jetty.client.api.Request;
+
+@FunctionalInterface
+public interface NameStrategy {
+    /**
+     * Determines the metric name to prefix request specific metrics (like
+     * time to first byte) based on request properties.
+     *
+     * @param request The request that the name should be created for
+     * @return The metric name
+     */
+    String nameFor(Request request);
+}

--- a/src/test/java/com/github/arteam/dropwizard/http2/client/Http2ClientIntegrationTest.java
+++ b/src/test/java/com/github/arteam/dropwizard/http2/client/Http2ClientIntegrationTest.java
@@ -13,7 +13,10 @@ import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.util.component.LifeCycle;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
 import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/com/github/arteam/dropwizard/http2/client/InstrumentedHttpClientTest.java
+++ b/src/test/java/com/github/arteam/dropwizard/http2/client/InstrumentedHttpClientTest.java
@@ -1,0 +1,93 @@
+package com.github.arteam.dropwizard.http2.client;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.github.arteam.dropwizard.http2.client.names.NameStrategies;
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.assertj.core.api.SoftAssertions;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.http.HttpClientTransportOverHTTP;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.junit.After;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InstrumentedHttpClientTest {
+    @ClassRule
+    public static final DropwizardAppRule<TestConfiguration> rule = new DropwizardAppRule<>(TestApplication.class,
+            ResourceHelpers.resourceFilePath("server.yml"));
+
+    private final MetricRegistry metrics = new MetricRegistry();
+    private HttpClient client;
+
+    @After
+    public void after() throws Exception {
+        if (client != null) {
+            client.stop();
+        }
+    }
+
+    @Test
+    public void testInstrumentation() throws Exception {
+        client = new InstrumentedHttpClient(new HttpClientTransportOverHTTP(),
+                null, metrics, NameStrategies.prefixedStrategy(MetricRegistry.name(HTTP2Client.class), NameStrategies.HOST));
+        client.start();
+        client.GET(String.format("http://127.0.0.1:%d/application/greet-chunk", rule.getLocalPort())).getContentAsString();
+        final Timer ttfb = metrics.getTimers().get("org.eclipse.jetty.http2.client.HTTP2Client.127.0.0.1.time-to-first-byte");
+        final Timer queueWait = metrics.getTimers().get("org.eclipse.jetty.http2.client.HTTP2Client.127.0.0.1.queue-wait");
+        final Timer total = metrics.getTimers().get("org.eclipse.jetty.http2.client.HTTP2Client.127.0.0.1.total");
+        final Meter request2xx = metrics.getMeters().get("org.eclipse.jetty.http2.client.HTTP2Client.127.0.0.1.2xx");
+        final Meter request5xx = metrics.getMeters().get("org.eclipse.jetty.http2.client.HTTP2Client.127.0.0.1.5xx");
+        final Meter request4xx = metrics.getMeters().get("org.eclipse.jetty.http2.client.HTTP2Client.127.0.0.1.4xx");
+        final Meter otherStatus = metrics.getMeters().get("org.eclipse.jetty.http2.client.HTTP2Client.127.0.0.1.other-status");
+        final Meter exception = metrics.getMeters().get("org.eclipse.jetty.http2.client.HTTP2Client.127.0.0.1.exception");
+
+        final SoftAssertions softly = new SoftAssertions();
+
+        softly.assertThat(total.getSnapshot().getMedian())
+                .isGreaterThanOrEqualTo(Duration.ofMillis(2500).toNanos())
+                .isLessThan(Duration.ofMillis(3000).toNanos());
+
+        softly.assertThat(ttfb.getSnapshot().getMedian())
+                .isGreaterThanOrEqualTo(Duration.ofMillis(500).toNanos())
+                .isLessThan(Duration.ofMillis(1000).toNanos());
+
+        softly.assertThat(queueWait.getSnapshot().getMedian())
+                .isGreaterThan(1)
+                .isLessThan(Duration.ofMillis(500).toNanos());
+
+        softly.assertThat(request2xx.getCount()).isEqualTo(1);
+        softly.assertThat(request4xx.getCount()).isEqualTo(0);
+        softly.assertThat(request5xx.getCount()).isEqualTo(0);
+        softly.assertThat(otherStatus.getCount()).isEqualTo(0);
+        softly.assertThat(exception.getCount()).isEqualTo(0);
+
+        softly.assertAll();
+    }
+
+    @Test
+    public void testMethodStrategy() throws Exception {
+        final MetricRegistry metrics = new MetricRegistry();
+        client = new InstrumentedHttpClient(new HttpClientTransportOverHTTP(),
+                null, metrics, NameStrategies.METHOD);
+        client.start();
+        client.GET(String.format("http://127.0.0.1:%d/application/greet-chunk", rule.getLocalPort())).getContentAsString();
+        assertThat(metrics.getTimers()).containsKey("GET.time-to-first-byte");
+    }
+
+    @Test
+    public void testFullNameStrategy() throws Exception {
+        final MetricRegistry metrics = new MetricRegistry();
+        client = new InstrumentedHttpClient(new HttpClientTransportOverHTTP(),
+                null, metrics, NameStrategies.FULL);
+        client.start();
+        client.GET(String.format("http://127.0.0.1:%d/application/greet-chunk", rule.getLocalPort())).getContentAsString();
+        assertThat(metrics.getTimers()).containsKey("127.0.0.1.GET./application/greet-chunk.time-to-first-byte");
+    }
+}

--- a/src/test/java/com/github/arteam/dropwizard/http2/client/TestResource.java
+++ b/src/test/java/com/github/arteam/dropwizard/http2/client/TestResource.java
@@ -1,8 +1,13 @@
 package com.github.arteam.dropwizard.http2.client;
 
+import org.glassfish.jersey.server.ChunkedOutput;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 /**
  * Date: 1/4/16
@@ -11,11 +16,36 @@ import javax.ws.rs.Produces;
  * @author Artem Prigoda
  */
 @Produces("application/json")
-@Path("greet")
+@Path("/")
 public class TestResource {
 
+    private ExecutorService executor = Executors.newCachedThreadPool();
+
     @GET
+    @Path("/greet")
     public Greeting greet() {
         return new Greeting("HTTP/2 server", "Hello, World!");
+    }
+
+    @GET
+    @Path("/greet-chunk")
+    public ChunkedOutput<String> greetChunk() throws InterruptedException {
+        final ChunkedOutput<String> output = new ChunkedOutput<>(String.class);
+
+        executor.execute(() -> {
+            try (ChunkedOutput<String> out = output) {
+                for (int i = 0; i < 5; i++) {
+                    Thread.sleep(500L);
+                    out.write("Hello world, I'm a HTTP/2 chunk server");
+                }
+            } catch (IOException ignored) {
+                throw new RuntimeException("Error writing output");
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        Thread.sleep(500L);
+        return output;
     }
 }

--- a/src/test/resources/server.yml
+++ b/src/test/resources/server.yml
@@ -1,0 +1,5 @@
+server:
+   type: 'simple'
+   connector:
+      type: 'http'
+      port: 0


### PR DESCRIPTION
Only `send()` is synchronous, and `send(Response.CompleteListener)` is asynchronous so the current timing mechanism will not work. Instead, hook onto the `Listener` API to provide counts for how many requests are in flights vs. in queue, as well for timings for how long in queue, time to first byte (ttfb), and how long the request took to finish.

This PR is very much WIP (no comments, tests, code thrown together in one file, correctness is undetermined), but wanted to get the PR out there to see if others think this is the right track for instrumentation.
