### PR TITLE
Fix build by referencing different http2 endpoint

### DIFF
--- a/src/test/java/com/github/arteam/dropwizard/http2/client/GoLangProxyIntegrationTest.java
+++ b/src/test/java/com/github/arteam/dropwizard/http2/client/GoLangProxyIntegrationTest.java
@@ -31,10 +31,7 @@ public class GoLangProxyIntegrationTest {
                     .request()
                     .get()
                     .readEntity(String.class);
-            assertThat(content).contains("Method: GET");
-            assertThat(content).contains("Protocol: HTTP/2.0");
-            assertThat(content).contains("Host: http2.golang.org:443");
-            assertThat(content).contains("RequestURI: \"/reqinfo\"");
+            assertThat(content).contains("\"Host\": \"nghttp2.org:443\"");
             now = System.currentTimeMillis();
             if (attempt++ % 5 == 0) { // 5 attempts reuse the same connection
                 Thread.sleep(4000); // Force reopening the connection

--- a/src/test/java/com/github/arteam/dropwizard/http2/client/GoLangProxyResource.java
+++ b/src/test/java/com/github/arteam/dropwizard/http2/client/GoLangProxyResource.java
@@ -23,6 +23,6 @@ public class GoLangProxyResource {
 
     @GET
     public String get() throws Exception {
-        return httpClient.GET("https://http2.golang.org/reqinfo").getContentAsString();
+        return httpClient.GET("https://nghttp2.org/httpbin/headers").getContentAsString();
     }
 }

--- a/src/test/java/com/github/arteam/dropwizard/http2/client/Http2ClientExternalServiceTest.java
+++ b/src/test/java/com/github/arteam/dropwizard/http2/client/Http2ClientExternalServiceTest.java
@@ -47,12 +47,9 @@ public class Http2ClientExternalServiceTest {
 
     @Test
     public void testExternalService() throws Exception {
-        String content = httpClient.GET("https://http2.golang.org/reqinfo")
+        String content = httpClient.GET("https://nghttp2.org/httpbin/headers")
                 .getContentAsString();
-        assertThat(content).contains("Method: GET");
-        assertThat(content).contains("Protocol: HTTP/2.0");
-        assertThat(content).contains("Host: http2.golang.org:443");
-        assertThat(content).contains("RequestURI: \"/reqinfo\"");
+        assertThat(content).contains("\"Host\": \"nghttp2.org:443\"");
     }
 }
 


### PR DESCRIPTION
I'm still looking into why `https://http2.golang.org/reqinfo` never resolves, but in the meantime this fix should do it.