### PR TITLE
Fix tests when user home directory contains space

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
                 <version>2.18.1</version>
                 <configuration>
                     <argLine>
-                        -Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar
+                        -Xbootclasspath/"p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
                     </argLine>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Currently the site used for the http2 tests appears to be having some difficulty, so this PR may fail, but I've personally tested this change on a box where the user contains a space in their home directory 😈 